### PR TITLE
Fix nginx reload bugs. 

### DIFF
--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -1697,6 +1697,9 @@ ngx_http_log_init(ngx_conf_t *cf)
 #include <ngx_setproctitle.h>
 #include <ngx_process.h>
 #include <sys/param.h>
+#if (NGX_LINUX)
+#include <linux/prctl.h>
+#endif
 
 #define MODULE_NAME "ngx_http_pipelog_module"
 #define LOGGER_PROC_NAME "logger process"
@@ -2106,8 +2109,6 @@ ngx_http_pipelog_init (ngx_conf_t *cf) {
 
 static ngx_pid_t
 ngx_http_pipelog_command_exec (ngx_str_t *command, ngx_fd_t rfd, ngx_cycle_t *cycle) {
-    ngx_core_conf_t *ccf;
-    ccf = (ngx_core_conf_t *)ngx_get_conf(cycle->conf_ctx, ngx_core_module);
     ngx_pid_t pid;
     char *argv[4], cmd[1024];
     ngx_fd_t fd;
@@ -2115,39 +2116,34 @@ ngx_http_pipelog_command_exec (ngx_str_t *command, ngx_fd_t rfd, ngx_cycle_t *cy
     if (command->len > sizeof(cmd) - 1) {
         return -1;
     }
-
-    switch (pid = fork())
-    {
-        case -1:
-            ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: ngx_http_pipelog_command_exec fork(): error", MODULE_NAME);
-            return NGX_ERROR;
-        case 0:
-            if(prctl(PR_SET_PDEATHSIG, SIGKILL) == -1) {
-                ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: ngx_http_pipelog_command_exec: prctl() failed", MODULE_NAME);
-            }
-            dup2(rfd, STDIN_FILENO);
-            for (fd = 0; fd < NOFILE; fd++) {
-                if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO) {
-                    close(fd);
-                }
-            }
-            memset(cmd, 0, sizeof(cmd));
-            memcpy(cmd, command->data, command->len);
-            argv[0] = SHELL_CMD;
-            argv[1] = "-c";
-            argv[2] = cmd;
-            argv[3] = NULL;
-            execvp(argv[0], argv);
-            exit(1);
-        default:
-            if (setresuid(0, 0, ccf->user) == -1) {
-                ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno, "%s: setresuid(%d, %d, %d) failed", MODULE_NAME, 0, 0, ccf->user);
-                /* fatal */
-                exit(2);
-            }
-
-            break;
+    pid = fork();
+    switch (pid){
+    case -1:
+        ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: ngx_http_pipelog_command_exec fork(): error", MODULE_NAME);
+        return NGX_ERROR;
+    case 0:
+#if (NGX_LINUX)
+        if(prctl(PR_SET_PDEATHSIG, SIGKILL) == -1) {
+            ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: ngx_http_pipelog_command_exec: prctl() failed", MODULE_NAME);
         }
+#endif
+        dup2(rfd, STDIN_FILENO);
+        for (fd = 0; fd < NOFILE; fd++) {
+            if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO) {
+                close(fd);
+            }
+        }
+        memset(cmd, 0, sizeof(cmd));
+        memcpy(cmd, command->data, command->len);
+        argv[0] = SHELL_CMD;
+        argv[1] = "-c";
+        argv[2] = cmd;
+        argv[3] = NULL;
+        execvp(argv[0], argv);
+        exit(1);
+    default:
+        break;
+    }
     return pid;
 }
 
@@ -2210,11 +2206,9 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
     sa.sa_handler = SIG_IGN;
     sigaction(SIGPIPE, &sa, NULL);
     sigemptyset(&set);
+    sigaddset(&set, SIGTERM);
     sigaddset(&set, SIGCHLD);
     sigprocmask(SIG_BLOCK, &set, NULL);
-
-    sigaddset(&set, SIGTERM);
-    sigaction(SIGTERM, &sa, NULL);
 
     gettimeofday(&now, NULL);
     pmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_pipelog_module);
@@ -2234,6 +2228,9 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
 
         if(sig == SIGTERM) {
             ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: ngx_http_pipelog_command_exec(): SIGTERM detected, gracefully shutting down...", MODULE_NAME);
+            if(killpg(0, SIGTERM) == -1) {
+                ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: ngx_http_pipelog_command_exec: killpg(%d, SIGTERM) failed ", MODULE_NAME, 0);
+            }
             _exit(0);
         }
 
@@ -2266,16 +2263,17 @@ static ngx_int_t
 init_module (ngx_cycle_t *cycle) {
     ngx_http_pipelog_main_conf_t *pmcf;
     ngx_fd_t fd;
+
     if (!ngx_test_config) {
         pmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_pipelog_module);
-        switch (pmcf->pid = fork())
-        {
+        pmcf->pid = fork();
+        switch (pmcf->pid) {
         case -1:
             ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: init_module fork(): error", MODULE_NAME);
             return NGX_ERROR;
         case 0:
-            if(setsid() == -1) {
-                ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: init_module: setsid() failed", MODULE_NAME);
+            if(setpgid(0, 0) == -1) {
+                ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: init_module: setpgid() failed", MODULE_NAME);
                 return NGX_ERROR;
             }
             fd = open("/dev/null", O_RDWR);
@@ -2292,17 +2290,15 @@ init_module (ngx_cycle_t *cycle) {
             break;
         }
     }
-
     return NGX_OK;
 }
 
 static void
 exit_process (ngx_cycle_t *cycle) {
     ngx_http_pipelog_main_conf_t *pmcf;
+
     pmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_pipelog_module);
-
     ngx_log_error(NGX_LOG_DEBUG, cycle->log, 0, "%s: exit_process called", MODULE_NAME);
-
     if(killpg(pmcf->pid, SIGTERM) == -1) {
         ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: exit_process: killpg(%d, SIGTERM) failed ", MODULE_NAME, pmcf->pid);
     }
@@ -2311,8 +2307,8 @@ exit_process (ngx_cycle_t *cycle) {
 static void
 exit_master (ngx_cycle_t *cycle) {
     ngx_http_pipelog_main_conf_t *pmcf;
-    pmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_pipelog_module);
 
+    pmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_pipelog_module);
     ngx_log_error(NGX_LOG_DEBUG, cycle->log, 0, "%s: exit_master called", MODULE_NAME);
     if(kill(pmcf->pid, SIGKILL) == -1) {
         ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: exit_master: kill(%d, SIGTERM) failed ", MODULE_NAME, pmcf->pid);


### PR DESCRIPTION
When nginx -s reload is called, pipelog does not quit and instead init_module() is called again, spawning a new set of pipelog processes. 

This change adds a numerous items; 

- Install a SIGTERM handler to send SIGTERM to the PGID, then gracefully _exit(0). The logger processes will also be sent the sigterm and depending on their implementation, they should gracefully exit. 
- Move setsid() up one fork so all processes are in the same PGID, which makes sending the group signals easier. 
- Add some more logging
- Add exit_process() callback
- Install child death handler into the forked child processes: If the parent process goes away, the forks will automatically be killed off
- Use switch() statements in the forks.
- Use killpg() in exit_process() 
- Sanity check various commands.
