### PR TITLE
Add setresuid() 

### DIFF
--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -2142,6 +2142,12 @@ ngx_http_pipelog_command_exec (ngx_str_t *command, ngx_fd_t rfd, ngx_cycle_t *cy
         execvp(argv[0], argv);
         exit(1);
     default:
+        if (setresuid(0, 0, ccf->user) == -1) {
+            ngx_log_error(NGX_LOG_EMERG, cycle->log, ngx_errno, "%s: setresuid(%d, %d, %d) failed", MODULE_NAME, 0, 0, ccf->user);
+            /* fatal */
+            exit(2);
+        }
+
         break;
     }
     return pid;


### PR DESCRIPTION
nginx: worker is responsible for spawning the nginx: logger process, but the nginx: worker process has a non-root UID, and the nginx: logger process is requires UID = 0.

So when a nginx -s reload is called, the current code gets EPERM because the worker process is trying to send killpg() and doesn't have permission. 

Call setresuid() so that the nginx: worker process has permissions to send signals to the nginx: logger and allow the nginx:
logger and it's forks to have a saved set-user-ID of the calling process.

This should solve any issues with nginx reloads not terminating nginx: logger processes.

