### PR TITLE
Fix last commit.

### DIFF
--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -2109,6 +2109,8 @@ ngx_http_pipelog_init (ngx_conf_t *cf) {
 
 static ngx_pid_t
 ngx_http_pipelog_command_exec (ngx_str_t *command, ngx_fd_t rfd, ngx_cycle_t *cycle) {
+    ngx_core_conf_t *ccf;
+    ccf = (ngx_core_conf_t *)ngx_get_conf(cycle->conf_ctx, ngx_core_module);
     ngx_pid_t pid;
     char *argv[4], cmd[1024];
     ngx_fd_t fd;


### PR DESCRIPTION
With this commit, it now works:

```
[pid  3918] rt_sigtimedwait([TERM CHLD], NULL, {tv_sec=1, tv_nsec=0}, 8) = -1 EAGAIN (Resource temporarily unavailable)
[pid  3918] rt_sigtimedwait([TERM CHLD], NULL, {tv_sec=1, tv_nsec=0}, 8 <unfinished ...>
[pid  3923] kill(-3918, SIGTERM)        = 0
[pid  3918] <... rt_sigtimedwait resumed>) = 15 (SIGTERM)
[pid  3918] kill(0, SIGTERM)            = 0
[pid  3918] +++ exited with 0 +++
[pid  3922] +++ killed by SIGKILL +++
[pid  3921] +++ killed by SIGKILL +++
+++ exited with 0 +++

```

