### PR TITLE
Do not block SIGTERM.

### DIFF
--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -2207,7 +2207,6 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
     sa.sa_handler = SIG_IGN;
     sigaction(SIGPIPE, &sa, NULL);
     sigemptyset(&set);
-    sigaddset(&set, SIGTERM);
     sigaddset(&set, SIGCHLD);
     sigprocmask(SIG_BLOCK, &set, NULL);
 


### PR DESCRIPTION
Bugfix: We need to be able to pass this to the process group/forks, so that any custom piped logger programs that have a signal handler for SIGTERM can cleanly shutdown. 

