### PR TITLE
Make sure SIGTERM can be used as a signal handler in children

### DIFF
--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -2207,6 +2207,7 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
     sa.sa_handler = SIG_IGN;
     sigaction(SIGPIPE, &sa, NULL);
     sigemptyset(&set);
+    sigaddset(&set, SIGTERM);
     sigaddset(&set, SIGCHLD);
     sigprocmask(SIG_BLOCK, &set, NULL);
 

--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -2209,7 +2209,6 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
     sigemptyset(&set);
     sigaddset(&set, SIGTERM);
     sigaddset(&set, SIGCHLD);
-    sigprocmask(SIG_BLOCK, &set, NULL);
 
     ccf = (ngx_core_conf_t *)ngx_get_conf(cycle->conf_ctx, ngx_core_module);
     if (geteuid() == 0) {

--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -2207,7 +2207,6 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
     sa.sa_handler = SIG_IGN;
     sigaction(SIGPIPE, &sa, NULL);
     sigemptyset(&set);
-    sigaddset(&set, SIGTERM);
     sigaddset(&set, SIGCHLD);
     sigprocmask(SIG_BLOCK, &set, NULL);
 


### PR DESCRIPTION
Fixes a bug where I noticed that forked processes were not seeing SIGTERM at all. 

