### PR TITLE
Remove SHELL_CMD and fix signals for child procs.

### DIFF
--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -2241,9 +2241,10 @@ ngx_http_pipelog_init (ngx_conf_t *cf) {
 }
 
 static ngx_pid_t
-ngx_http_pipelog_command_exec (wordexp_t *w, ngx_fd_t rfd, ngx_cycle_t *cycle, sigset_t mask) {
+ngx_http_pipelog_command_exec (wordexp_t *w, ngx_fd_t rfd, ngx_cycle_t *cycle) {
     ngx_pid_t pid;
     ngx_fd_t fd;
+    sigset_t mask;
 
     if (!w) {
         return -1;
@@ -2254,7 +2255,6 @@ ngx_http_pipelog_command_exec (wordexp_t *w, ngx_fd_t rfd, ngx_cycle_t *cycle, s
         ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: ngx_http_pipelog_command_exec fork(): error", MODULE_NAME);
         return NGX_ERROR;
     case 0:
-        sigprocmask(SIG_SETMASK, &mask, NULL);
         dup2(rfd, STDIN_FILENO);
         for (fd = 0; fd < NOFILE; fd++) {
             if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO) {
@@ -2272,7 +2272,7 @@ ngx_http_pipelog_command_exec (wordexp_t *w, ngx_fd_t rfd, ngx_cycle_t *cycle, s
 }
 
 static ngx_uint_t
-ngx_http_pipelog_reap_child (ngx_cycle_t *cycle, sigset_t mask) {
+ngx_http_pipelog_reap_child (ngx_cycle_t *cycle) {
     struct timeval now, diff;
     ngx_http_pipelog_main_conf_t *pmcf;
     ngx_uint_t num, idx;
@@ -2302,7 +2302,7 @@ ngx_http_pipelog_reap_child (ngx_cycle_t *cycle, sigset_t mask) {
             continue;
         }
         pim[idx].timestamp = now;
-        pim[idx].pid = ngx_http_pipelog_command_exec(&pim[idx].w, pim[idx].fd[0], cycle, mask);
+        pim[idx].pid = ngx_http_pipelog_command_exec(&pim[idx].w, pim[idx].fd[0], cycle);
         if (pim[idx].pid == -1) {
             ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: reap child process (pid='%d'), respawn child process failed", MODULE_NAME, pid);
             continue;
@@ -2315,7 +2315,7 @@ ngx_http_pipelog_reap_child (ngx_cycle_t *cycle, sigset_t mask) {
 void
 ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
     struct sigaction sa;
-    sigset_t set, old;
+    sigset_t set;
     ngx_core_conf_t *ccf;
     struct timeval now, diff;
     ngx_http_pipelog_main_conf_t *pmcf;
@@ -2333,7 +2333,7 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
     sigemptyset(&set);
     sigaddset(&set, SIGTERM);
     sigaddset(&set, SIGCHLD);
-    sigprocmask(SIG_BLOCK, &set, &old);
+    sigprocmask(SIG_BLOCK, &set, NULL);
 
     ccf = (ngx_core_conf_t *)ngx_get_conf(cycle->conf_ctx, ngx_core_module);
     if (geteuid() == 0) {
@@ -2347,7 +2347,7 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
     pmcf = ngx_http_cycle_get_module_main_conf(cycle, ngx_http_pipelog_module);
     pim = pmcf->pims.elts;
     for (idx = 0; idx < pmcf->pims.nelts; idx++) {
-        pim[idx].pid = ngx_http_pipelog_command_exec(&pim[idx].w, pim[idx].fd[0], cycle, old);
+        pim[idx].pid = ngx_http_pipelog_command_exec(&pim[idx].w, pim[idx].fd[0], cycle);
         if (pim[idx].pid == -1) {
             ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: ngx_http_pipelog_command_exec(): error", MODULE_NAME);
         }
@@ -2368,7 +2368,7 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
         }
 
         if (sig != -1) {
-            ngx_http_pipelog_reap_child(cycle, old);
+            ngx_http_pipelog_reap_child(cycle);
         } else {
             gettimeofday(&now, NULL);
             pim = pmcf->pims.elts;
@@ -2381,7 +2381,7 @@ ngx_http_pipelog_logger_process_main (ngx_cycle_t *cycle) {
                     continue;
                 }
                 pim[idx].timestamp = now;
-                pim[idx].pid = ngx_http_pipelog_command_exec(&pim[idx].w, pim[idx].fd[0], cycle, old);
+                pim[idx].pid = ngx_http_pipelog_command_exec(&pim[idx].w, pim[idx].fd[0], cycle);
                 if (pim[idx].pid == -1) {
                     ngx_log_error(NGX_LOG_ALERT, cycle->log, 0, "%s: respawn child process failed", MODULE_NAME);
                     continue;

--- a/ngx_http_pipelog_module.c
+++ b/ngx_http_pipelog_module.c
@@ -2073,7 +2073,7 @@ ngx_http_pipelog_set_log (ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
     }
     pipelog->pim->command = value[1];
 
-    int result = wordexp((const char*)value[1].data, &w, WRDE_NOCMD);
+    int result = wordexp((const char*)value[1].data, &w, 0);
     if (result != 0) {
         ngx_conf_log_error(NGX_LOG_EMERG, cf, 0, "wrong command syntax(%i): %s", result, value[1].data);
         return NGX_CONF_ERROR;
@@ -2267,13 +2267,13 @@ ngx_http_pipelog_command_exec (ngx_str_t *command, ngx_fd_t rfd, ngx_cycle_t *cy
         memset(cmd, 0, sizeof(cmd));
         memcpy(cmd, command->data, command->len);
 
-        if (wordexp(cmd, &w, WRDE_NOCMD) == 0) {
+        if (wordexp(cmd, &w, 0) == 0) {
             if (w.we_wordc > 0) {
                 char *bin = w.we_wordv[0];
                 if (*bin) {
                     sigfillset(&mask);
                     sigprocmask(SIG_UNBLOCK, &mask, NULL);
-                    execve(bin, w.we_wordv, NULL);
+                    execvp(bin, w.we_wordv);
                 }
             }
             wordfree(&w);


### PR DESCRIPTION
On Ubuntu, it defaults /bin/sh to the dash shell, which has some kind of strange monitor mode, unlike bash. It's just better to directly call execve() on the logger program, just like Apache's piped logging. 

Also, we should unblock signals just before execve() so downstream processes can see SIGTERM etc. 
